### PR TITLE
Learn complytime/step 2

### DIFF
--- a/markdown/component-definitions/My-Test-Component/My-Test-Component/rhel10-anssi-enhanced/r10/r10.md
+++ b/markdown/component-definitions/My-Test-Component/My-Test-Component/rhel10-anssi-enhanced/r10/r10.md
@@ -14,7 +14,7 @@ x-trestle-global:
 
 ## Control Statement
 
-The loading of the kernel modules can be blocked by the activation of the sysctl kernel.modules_disabled: Prohibition of loading modules (except those already loaded to this point) kernel.modules_disabled = 1
+The loading of the kernel modules can be blocked by the activation of the sysctl kernel.modules_disabled: Prohibition of loading modules (except those already loaded to this point) kernel.modules_disabled = 5
 
 ______________________________________________________________________
 

--- a/markdown/component-definitions/My-Test-Component/My-Test-Component/rhel10-anssi-enhanced/r11/r11.md
+++ b/markdown/component-definitions/My-Test-Component/My-Test-Component/rhel10-anssi-enhanced/r11/r11.md
@@ -14,7 +14,7 @@ x-trestle-global:
 
 ## Control Statement
 
-It is recommended to load the Yama security module at startup (by example passing the security = yama argument to the kernel) and configure the sysctl kernel.yama.ptrace_scope to a value of at least 1.
+It is recommended to load the Yama security module at startup (by example passing the security = yama argument to the kernel) and configure the sysctl kernel.yama.ptrace_scope to a value of at least 10.
 
 ______________________________________________________________________
 

--- a/markdown/component-definitions/My-Test-Component/My-Test-Component/rhel10-anssi-enhanced/r12/r12.md
+++ b/markdown/component-definitions/My-Test-Component/My-Test-Component/rhel10-anssi-enhanced/r12/r12.md
@@ -14,6 +14,7 @@ x-trestle-global:
 
 ## Control Statement
 
+This is an example control statement for Creme Brulee.
 ______________________________________________________________________
 
 ## What is the solution and how is it implemented?


### PR DESCRIPTION
## Summary
Three changes were made to Component Definitions (one each in R10, R11, and R12)

## Related Issues

- N/A

## Rationale 
*In r10.md, a value on line 17 was changed from 1 to 5.
*In r11.md, a value on line 17 was changed from 1 to 10.
*In r12.md, a component summary was created on line 17.

#### What did you update?

- [ ] OSCAL Catalogs
- [ ] OSCAL Profiles
- [X] OSCAL Component Definitions
- [ ] Markdown OSCAL Catalogs
- [ ] Markdown OSCAL Profiles
- [ ] Markdown OSCAL Component Definitions

#### What ComplianceAsCode/content resources did you leverage?

- [ ] [Controls](https://github.com/ComplianceAsCode/content/tree/master/controls)
- [ ] Profiles: [RHEL8](https://github.com/ComplianceAsCode/content/tree/master/products/rhel8/profiles), [RHEL9](https://github.com/ComplianceAsCode/content/tree/master/products/rhel9/profiles),  [RHEL10](https://github.com/ComplianceAsCode/content/tree/master/products/rhel10/profiles)
- [ ] [Products](https://github.com/ComplianceAsCode/content/tree/master/products)

## Questions 

Any questions can be left in the comments. Tag @hbraswelrh for more info. Escalate any issues via Slack in the #learn-complytime Slack Channel.

